### PR TITLE
Add support for OpenLayers 3

### DIFF
--- a/MapModifier.js
+++ b/MapModifier.js
@@ -253,6 +253,7 @@ define(function(require, exports, module) {
             var rotateTowards = this._rotateTowardsGetter ? this._rotateTowardsGetter() : this._rotateTowards;
             if (rotateTowards) {
                 var rotation = MapUtility.rotationFromPositions(position, rotateTowards);
+                rotation += this.mapView.getRotation();
                 if (this._cache.rotation !== rotation) {
                     this._cache.rotation = rotation;
                     this._cache.rotate = Transform.rotateZ(rotation);

--- a/MapView.js
+++ b/MapView.js
@@ -230,6 +230,20 @@ define(function(require, exports, module) {
     };
 
     /**
+     * Get the rotation of the map. 0 means north-up.
+     * @return {Number} Rotation in radians.
+     */
+    MapView.prototype.getRotation = function() {
+        switch (this.mapType) {
+        case MapType.GOOGLEMAPS:
+        case MapType.LEAFLET:
+            return 0;
+        case MapType.OPENLAYERS3:
+            return this.map.getView().getRotation();
+        }
+    };
+
+    /**
      * Get the position in pixels (relative to the left-top of the container) for the given geographical position.
      *
      * @param {LatLng} position in geographical coordinates.

--- a/MapView.js
+++ b/MapView.js
@@ -8,7 +8,7 @@
  * @copyright Gloey Apps, 2014
  */
 
-/*global google, L*/
+/*global google, L, ol*/
 
 /**
  * MapView encapsulates a Google maps view so it can be used with famo.us.
@@ -22,6 +22,7 @@
  * |---|---|
  * |MapType.GOOGLEMAPS (default)|Google-maps.|
  * |MapType.LEAFLET|Leaflet.js.|
+ * |MapType.OPENLAYERS3|OpenLayers.|
  * @module
  */
 define(function(require, exports, module) {
@@ -44,13 +45,14 @@ define(function(require, exports, module) {
      */
     var MapType = {
         GOOGLEMAPS: 1,
-        LEAFLET: 2
+        LEAFLET: 2,
+        OPENLAYERS3: 3
     };
 
     /**
      * @class
      * @param {Object} options Options.
-     * @param {MapType} options.type Map-type (e.g. MapView.MapType.GOOGLEMAPS, MapView.MapType.LEAFLET).
+     * @param {MapType} options.type Map-type (e.g. MapView.MapType.GOOGLEMAPS, MapView.MapType.LEAFLET, MapView.MapType.OPENLAYERS3).
      * @param {Object} options.mapOptions Options that are passed directly to the Map object. The options should include the 'center' and 'zoom'.
      * @param {String} [options.id] Id of the DOM-element to use. When ommitted, a DOM-element is created using a surface.
      * @param {Transition} [options.zoomTransition] Transition to use for smoothly zooming renderables (by default a transition of 120 ms is used).
@@ -92,6 +94,7 @@ define(function(require, exports, module) {
                 size: [undefined, undefined]
             });
             this.add(surface);
+            this._surface = surface;
         }
     }
     MapView.prototype = Object.create(View.prototype);
@@ -149,6 +152,27 @@ define(function(require, exports, module) {
             this.map = L.map(elm, this.options.mapOptions);
             this._initComplete = true;
             this._eventOutput.emit('load', this);
+            break;
+
+        // Create ol3 Map
+        case MapType.OPENLAYERS3:
+            var options = this.options.mapOptions;
+            var center = options.center;
+            this.map = new ol.Map({
+                target: elm,
+                controls: ol.control.defaults({attributionOptions: {collapsible: false}}),
+                view: new ol.View({
+                    center: ol.proj.transform([center.lng, center.lat], 'EPSG:4326', 'EPSG:3857'),
+                    zoom: options.zoom
+                })
+            });
+            this._surface.on('resize', function() {
+                this.map.updateSize();
+            }.bind(this));
+            this.map.once('postrender', function() {
+                this._initComplete = true;
+                this._eventOutput.emit('load', this);
+            }.bind(this));
             break;
         }
     };
@@ -212,6 +236,7 @@ define(function(require, exports, module) {
      * @return {Point} Position in pixels, relative to the left-top of the mapView.
      */
     MapView.prototype.pointFromPosition = function(position) {
+        var pnt;
         switch (this.mapType) {
         case MapType.GOOGLEMAPS:
             if (!(position instanceof google.maps.LatLng)) {
@@ -224,8 +249,12 @@ define(function(require, exports, module) {
             };
         case MapType.LEAFLET:
             // Note: smooth zooming is not yet supported for leaflet
-            var pnt = this.map.latLngToContainerPoint(position);
+            pnt = this.map.latLngToContainerPoint(position);
             return pnt;
+        case MapType.OPENLAYERS3:
+            // Note: updates during map interaction are not yet supported
+            pnt = this.map.getPixelFromCoordinate(ol.proj.transform([position.lng, position.lat], 'EPSG:4326', 'EPSG:3857'));
+            return {x: pnt[0], y: pnt[1]};
         }
     };
 
@@ -246,6 +275,10 @@ define(function(require, exports, module) {
         case MapType.LEAFLET:
             // Note: smooth zooming is not yet supported for leaflet
             return this.map.containerPointToLatLng(point);
+        case MapType.OPENLAYERS3:
+            // Note: updates during map interaction are not yet supported
+            var lonLat = ol.proj.transform(this.map.getCoordinateFromPixel([point.x, point.y]), 'EPSG:3857', 'EPSG:4326');
+            return {lat: lonLat[1], lng: lonLat[0]};
         }
     };
 
@@ -309,6 +342,9 @@ define(function(require, exports, module) {
             var point = this.map.getSize();
             this._cache.size = [point.x, point.y];
             break;
+        case MapType.OPENLAYERS3:
+            this._cache.size = this.map.getSize();
+            break;
         }
 
         // Calculate current world point edges and scale
@@ -330,8 +366,10 @@ define(function(require, exports, module) {
             this._cache.zoom = Math.log(this._cache.scale) / Math.log(2);
             break;
         case MapType.LEAFLET:
+        case MapType.OPENLAYERS3:
 
-            // Note: smooth zooming is not yet supported for leaflet
+            // Note: smooth zooming is not yet supported for leaflet, and
+            // updates during map interaction are not yet supported for ol3
             this._cache.zoom = zoom;
             break;
         }
@@ -397,6 +435,18 @@ define(function(require, exports, module) {
                 center: {lat: center.lat, lng: center.lng},
                 southWest: {lat: southWest.lat, lng: southWest.lng},
                 northEast: {lat: northEast.lat, lng: northEast.lng}
+            };
+        case MapType.OPENLAYERS3:
+            var view = this.map.getView();
+            bounds = ol.proj.transformExtent(view.calculateExtent(this.map.getSize()), 'EPSG:3857', 'EPSG:4326');
+            center = ol.proj.transform(view.getCenter(), 'EPSG:3857', 'EPSG:4326');
+            zoom = view.getZoom();
+            return {
+                zoom: zoom,
+                center: {lat: center[1], lng: center[0]},
+                southWest: {lat: bounds[1], lng: bounds[0]},
+                northEast: {lat: bounds[3], lng: bounds[2]},
+                rotation: view.getRotation()
             };
         }
     };
@@ -464,6 +514,9 @@ define(function(require, exports, module) {
                     break;
                 case MapType.LEAFLET:
                     this.map.panTo(options.center, {animate: false});
+                    break;
+                case MapType.OPENLAYERS3:
+                    this.map.getView().setCenter(ol.proj.transform([options.center.lng, options.center.lat], 'EPSG:4326', 'EPSG:3857'));
                     break;
                 }
             }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Map component for Famo.us, supporting the following map-providers:
 
 - [Google Maps](https://developers.google.com/maps/documentation)
 - [Leaflet.js](http://leafletjs.com) (OpenStreetMap)
+- [OpenLayers 3](http://openlayers.org) (any base map)
 
 Famous-map makes it possible for adding a map-component to the famo.us render-tree. Additionally, famous transitions can be used to pan the map and modifiers can be used to sync the position of renderables with a geographical position.
 
@@ -97,6 +98,42 @@ mapView.on('load', function () {
     L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>'
 	}).addTo(mapView.getMap());
+}.bind(this));
+```
+
+### OpenLayers 3
+
+Include OpenLayers in the html file:
+
+```html
+<head>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.3.0/ol.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.3.0/ol.js"></script>
+</head>
+```
+
+Create a leaflet map:
+
+```javascript
+var MapView = require('famous-map/MapView');
+
+var mapView = new MapView({
+	type: MapView.MapType.OPENLAYERS3,
+    mapOptions: {
+        zoom: 3,
+        center: {lat: 51.4484855, lng: 5.451478}
+    }
+});
+this.add(mapView);
+
+// Wait for the map to load and initialize
+mapView.on('load', function () {
+
+    // Add tile-layer (OSM is just one of many options)
+		mapView.getMap().addLayer(new ol.layer.Tile({
+			source: new ol.source.OSM()
+		}));
+
 }.bind(this));
 ```
 

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -6,7 +6,7 @@
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-        
+
         <!-- shims for backwards compatibility -->
         <script type="text/javascript" src="https://code.famo.us/lib/functionPrototypeBind.js"></script>
         <script type="text/javascript" src="https://code.famo.us/lib/classList.js"></script>
@@ -14,17 +14,17 @@
 
         <!-- google maps -->
         <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false"></script>
-        
+
         <!-- module loader -->
         <script type="text/javascript" src="https://code.famo.us/lib/require.js"></script>
 
         <!-- famous -->
         <link rel="stylesheet" type="text/css" href="https://code.famo.us/famous/0.3/famous.css" />
         <script type="text/javascript" src="https://code.famo.us/famous/0.3/famous.min.js"></script>
-        
+
         <!-- famous-map -->
         <script type="text/javascript" src="../../dist/famous-map.min.js"></script>
-        
+
         <!-- app code -->
         <link rel="stylesheet" type="text/css" href="styles.css" />
         <script type="text/javascript">
@@ -33,6 +33,6 @@
 
     </head>
     <body>
-        <a class='provider' href='leaflet.html'>Switch to Leaflet / OSM</a>
+        <span class='provider'>Switch to <a href='openlayers3.html'>ol3</a> / <a href='leaflet.html'>Leaflet</a></span
     </body>
 </html>

--- a/examples/demo/main.js
+++ b/examples/demo/main.js
@@ -119,8 +119,9 @@ define(function (require) {
     // Create instructions
     //
     var instructions = new Surface({
-        size: [300, 140],
-        content: 'Things to try out:<li>Move the map</li><li>Zoom the map</li><li>Click on a landmark</li>',
+        size: [400, 140],
+        content: 'Things to try out:<li>Move the map</li><li>Zoom the map</li><li>Click on a landmark</li>' +
+            (mapType === MapView.MapType.OPENLAYERS3 ? '<li>Rotate the map (Alt+Shift+Drag)</li>' : ''),
         classes: ['instruction']
     });
     var instructionsModifier = new Modifier({

--- a/examples/demo/main.js
+++ b/examples/demo/main.js
@@ -1,16 +1,16 @@
-/* 
+/*
  * Copyright (c) 2014 Gloey Apps
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,7 +18,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- * 
+ *
  * @author: Hein Rutjes (IjzerenHein)
  * @license MIT
  * @copyright Gloey Apps, 2014
@@ -29,7 +29,7 @@
 
 define(function (require) {
     'use strict';
-    
+
     // import dependencies
     var Engine = require('famous/core/Engine');
     var FastClick = require('famous/inputs/FastClick');
@@ -38,7 +38,7 @@ define(function (require) {
     var ImageSurface = require('famous/surfaces/ImageSurface');
     var Transform = require('famous/core/Transform');
     var Easing = require('famous/transitions/Easing');
-    
+
     var MapView = require('famous-map/MapView');
     var MapModifier = require('famous-map/MapModifier');
     var MapStateModifier = require('famous-map/MapStateModifier');
@@ -49,13 +49,15 @@ define(function (require) {
 
     // create the main context
     var mainContext = Engine.createContext();
-    
+
     // Determine map-type
     var mapType;
-    try {
+    if ('L' in window && typeof L.Map == 'function') {
         var l = L;
         mapType = MapView.MapType.LEAFLET;
-    } catch (err) {
+    } else if ('ol' in window && typeof ol.Map == 'function') {
+        mapType = MapView.MapType.OPENLAYERS3;
+    } else {
         mapType = MapView.MapType.GOOGLEMAPS;
     }
 
@@ -67,8 +69,9 @@ define(function (require) {
     var mapView;
     switch (mapType) {
     case MapView.MapType.LEAFLET:
-        
-        // Create leaflet map-view
+    case MapView.MapType.OPENLAYERS3:
+
+        // Create leaflet or ol3 map-view
         mapView = new MapView({
             type: mapType,
             mapOptions: {
@@ -78,7 +81,7 @@ define(function (require) {
         });
         break;
     case MapView.MapType.GOOGLEMAPS:
-        
+
         // Create google-maps map-view
         mapView = new MapView({
             type: mapType,
@@ -94,7 +97,7 @@ define(function (require) {
         break;
     }
     mainContext.add(mapView);
-    
+
     //
     // Create title
     //
@@ -109,9 +112,9 @@ define(function (require) {
         transform: Transform.translate(0, 20, 0)
     });
     mainContext.add(titleModifier).add(title);
-    
-    
-    
+
+
+
     //
     // Create instructions
     //
@@ -125,8 +128,8 @@ define(function (require) {
         origin: [0.0, 1.0]
     });
     mainContext.add(instructionsModifier).add(instructions);
-    
-    
+
+
     //
     // Wait for the map to load and initialize
     //
@@ -138,8 +141,10 @@ define(function (require) {
                 attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>'
                 //maxZoom: 18
             }).addTo(mapView.getMap());
+        } else if (mapType === MapView.MapType.OPENLAYERS3) {
+            mapView.getMap().addLayer(new ol.layer.Tile({source: new ol.source.OSM()}));
         }
-        
+
         //
         // Create compass
         //
@@ -158,8 +163,8 @@ define(function (require) {
             //zoomBase: 14
         });
         mainContext.add(compassModifier).add(compassMapModifier).add(compass);
-        
-        
+
+
         //
         // Define landmarks
         //
@@ -184,7 +189,7 @@ define(function (require) {
             }
         ];
         function _panToLandmark(e) {
-            
+
             // Move the center of the map to the landmark
             var center = this.getPosition();
             mapView.halt();
@@ -192,14 +197,14 @@ define(function (require) {
                 {lat: MapUtility.lat(center) - 0.006, lng: MapUtility.lng(center)},
                 { duration: 1000, curve: Easing.outBack }
             );
-            
+
             // Position the compass just below the landmark and make it rotate towards it
             compassMapModifier.rotateTowardsFrom(this.getPosition());
         }
         for (i = 0; i < landmarks.length; i++) {
             var landmark = landmarks[i];
-            
-            
+
+
             //
             // Create landmark
             //
@@ -218,8 +223,8 @@ define(function (require) {
             });
             image.on('click', _panToLandmark.bind(mapModifier));
             mainContext.add(mapModifier).add(modifier).add(image);
-            
-            
+
+
             //
             // Create info-box for the landmark
             //
@@ -241,11 +246,11 @@ define(function (require) {
             info.on('click', _panToLandmark.bind(mapModifier));
             mainContext.add(infoMapModifier).add(infoModifier).add(info);
         }
-        
-        
+
+
         //
         // Create a traveller which drives around
-        // 
+        //
         var roundabout = [
             {lat: 51.4347897, lng: 5.452068},
             {lat: 51.4470413, lng: 5.4474332},
@@ -275,8 +280,8 @@ define(function (require) {
             zoomBase: 15
         });
         mainContext.add(travellerMapModifier).add(travellerModifier).add(traveller);
-        
-        
+
+
         //
         // Let the traveller drive around the roundabout
         //
@@ -292,7 +297,7 @@ define(function (require) {
             );
         }
         _driveRoundabout();
-        
+
         // Let the compass rotate towards the traveller
         compassMapModifier.rotateTowardsFrom(travellerMapModifier);
     });

--- a/examples/demo/openlayers3.html
+++ b/examples/demo/openlayers3.html
@@ -12,9 +12,9 @@
         <script type="text/javascript" src="https://code.famo.us/lib/classList.js"></script>
         <script type="text/javascript" src="https://code.famo.us/lib/requestAnimationFrame.js"></script>
 
-        <!-- leaflet / open street maps -->
-        <link rel="stylesheet" href="https://rawgit.com/IjzerenHein/leaflet-dist/master/leaflet.css" />
-        <script src="https://rawgit.com/IjzerenHein/leaflet-dist/master/leaflet.js"></script>
+        <!-- openlayers -->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.3.0/ol.min.css" />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.3.0/ol.js"></script>
 
         <!-- module loader -->
         <script type="text/javascript" src="https://code.famo.us/lib/require.js"></script>
@@ -34,6 +34,6 @@
 
     </head>
     <body>
-        <span class='provider'>Switch to <a href='index.html'>Google Maps</a> / <a href='openlayers3.html'>ol3</a></span
+        <span class='provider'>Switch to <a href='index.html'>Google Maps</a> / <a href='leaflet.html'>Leaflet</a></span
     </body>
 </html>

--- a/examples/demo/styles.css
+++ b/examples/demo/styles.css
@@ -17,6 +17,10 @@ body, div, a {
     border-radius: 5px;
 }
 
+.provider a {
+    color: white;
+}
+
 .title {
     color: black;
     font-weight: bold;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "maps",
     "leaflet",
     "leafletjs",
+    "openlayers",
     "openstreetmap",
     "mapbox"
   ],


### PR DESCRIPTION
This implements all functions in MapView.js for OpenLayers 3. The demo example now also has an OpenLayers 3 version. Rotation support is implemented as well.

Fixes #17.
